### PR TITLE
fix: Take ownership in example w/ self.run()

### DIFF
--- a/content/blog/actors-with-tokio/index.md
+++ b/content/blog/actors-with-tokio/index.md
@@ -236,7 +236,7 @@ That said, there is a version that works. By fixing the two above problems, you
 end up with the following:
 ```rust
 impl MyActor {
-    async fn run(&mut self) {
+    async fn run(mut self) {
         while let Some(msg) = self.receiver.recv().await {
             self.handle_message(msg);
         }


### PR DESCRIPTION
Thank you for this classic article. I noticed `async fn run(&mut self)` should take ownership rather than a reference.

This is your example adapted to use `run` rather than the separate `run_my_actor`:
https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=cee7d7819b3682a353b8150777bd5a46

It will compile by removing the `&`: `async fn run(mut self)` .
https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=e0941aaa6df6acb39f93b05c7e6bbe65